### PR TITLE
Tsa 227/device management service

### DIFF
--- a/Device-Management/pom.xml
+++ b/Device-Management/pom.xml
@@ -3,7 +3,7 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>org.springframework</groupId>
+    <groupId>org.tempusboard</groupId>
     <artifactId>Device-Management-Service</artifactId>
     <version>0.1.0</version>
 
@@ -21,14 +21,6 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-jdbc</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-jdbc</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/Device-Management/pom.xml
+++ b/Device-Management/pom.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.springframework</groupId>
+    <artifactId>Device-Management-Service</artifactId>
+    <version>0.1.0</version>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>1.5.7.RELEASE</version>
+    </parent>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-jdbc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-jdbc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-devtools</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.jayway.jsonpath</groupId>
+            <artifactId>json-path</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.googlecode.json-simple</groupId>
+            <artifactId>json-simple</artifactId>
+            <version>1.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.7</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.2</version>
+        </dependency>
+    </dependencies>
+
+    <properties>
+        <java.version>1.8</java.version>
+    </properties>
+
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+        <resources>
+        <resource>
+        <directory>src/main/resources</directory>
+        <excludes>
+            <exclude>**/*.bmp</exclude>
+            <exclude>**/*.jpg</exclude>
+            <exclude>**/*.jpeg</exclude>
+            <exclude>**/*.gif</exclude>
+        </excludes>
+        </resource>
+        </resources>
+    </build>
+
+    <repositories>
+        <repository>
+            <id>spring-releases</id>
+            <url>https://repo.spring.io/libs-release</url>
+        </repository>
+    </repositories>
+    <pluginRepositories>
+        <pluginRepository>
+            <id>spring-releases</id>
+            <url>https://repo.spring.io/libs-release</url>
+        </pluginRepository>
+    </pluginRepositories>
+</project>

--- a/Device-Management/src/main/java/org/thingsboard/device/shadow/Application.java
+++ b/Device-Management/src/main/java/org/thingsboard/device/shadow/Application.java
@@ -2,12 +2,9 @@ package org.thingsboard.device.shadow;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.context.annotation.ComponentScan;
 
 @SpringBootApplication
-public class
-
-Application {
+public class Application {
     public static void main(String[] args) {
         SpringApplication.run(Application.class, args);
     }

--- a/Device-Management/src/main/java/org/thingsboard/device/shadow/Application.java
+++ b/Device-Management/src/main/java/org/thingsboard/device/shadow/Application.java
@@ -2,9 +2,12 @@ package org.thingsboard.device.shadow;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.ComponentScan;
 
 @SpringBootApplication
-public class Application {
+public class
+
+Application {
     public static void main(String[] args) {
         SpringApplication.run(Application.class, args);
     }

--- a/Device-Management/src/main/java/org/thingsboard/device/shadow/Application.java
+++ b/Device-Management/src/main/java/org/thingsboard/device/shadow/Application.java
@@ -1,0 +1,11 @@
+package org.thingsboard.device.shadow;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class Application {
+    public static void main(String[] args) {
+        SpringApplication.run(Application.class, args);
+    }
+}

--- a/Device-Management/src/main/java/org/thingsboard/device/shadow/components/ConfigProperties.java
+++ b/Device-Management/src/main/java/org/thingsboard/device/shadow/components/ConfigProperties.java
@@ -1,0 +1,31 @@
+package org.thingsboard.device.shadow.components;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+/**
+ * Created by himanshu on 24/10/17.
+ */
+@Component
+public class ConfigProperties {
+    @Value("${spring.datasource.url}")
+    private String DB_URL;
+
+    @Value("${spring.datasource.username}")
+    private String USER;
+
+    @Value("${spring.datasource.password}")
+    private String PASS;
+
+    public String getDB_URL() {
+        return DB_URL;
+    }
+
+    public String getUSER() {
+        return USER;
+    }
+
+    public String getPASS() {
+        return PASS;
+    }
+}

--- a/Device-Management/src/main/java/org/thingsboard/device/shadow/controllers/ShadowController.java
+++ b/Device-Management/src/main/java/org/thingsboard/device/shadow/controllers/ShadowController.java
@@ -1,9 +1,5 @@
 package org.thingsboard.device.shadow.controllers;
 
-/**
- * Created by himanshu on 29/9/17.
- */
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.json.simple.JSONArray;
 import org.json.simple.parser.JSONParser;
@@ -32,14 +28,16 @@ public class ShadowController {
         JSONParser parser = new JSONParser();
         JSONObject jsonObject = null;
         JSONArray tagList = null;
+        String status = "";
         try {
             jsonObject = (JSONObject) parser.parse(availableTags);
-            dataService.updateAvailableTags(jsonObject);
+            logger.debug("UPDATE OBJ : \n" + jsonObject + "\n");
+            status =dataService.updateAvailableTags(jsonObject);
         }catch (Exception e){
             logger.error("Exception updating tags : " + e);
-            return "{\"error\":\""+e+"\"}";
+            status =  "{\"error\":\""+e+"\"}";
         }
-        return "{\"status\":\"updated\"}";
+        return status;
     }
 
     @RequestMapping(value = "/desired/tags", method = RequestMethod.POST)
@@ -73,8 +71,14 @@ public class ShadowController {
     }
 
     @RequestMapping(value = "/available/tags", produces = "application/json", method = RequestMethod.GET)
-    public String getAvailableTagsByToken(@RequestParam(value="token") String token) {
-        String jsonTagList = dataService.getAvailableTagsBytoken(token);
+    public String getAvailableTagsByDevice(@RequestParam(value="deviceName") String device) {
+        String jsonTagList = dataService.getAvailableTagsByDevice(device);
         return jsonTagList;
+    }
+
+    @RequestMapping(value = "/device/shadow", produces = "application/json", method = RequestMethod.GET)
+    public String getDeviceShadow(@RequestParam(value="deviceName") String device) {
+        String jsonShadow = dataService.getDeviceShadow(device);
+        return jsonShadow;
     }
 }

--- a/Device-Management/src/main/java/org/thingsboard/device/shadow/controllers/ShadowController.java
+++ b/Device-Management/src/main/java/org/thingsboard/device/shadow/controllers/ShadowController.java
@@ -8,6 +8,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.json.simple.JSONArray;
 import org.json.simple.parser.JSONParser;
 import org.json.simple.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
 import org.thingsboard.device.shadow.models.TagList;
 import org.thingsboard.device.shadow.services.DataService;
@@ -20,49 +23,71 @@ import java.util.concurrent.atomic.AtomicLong;
 @RestController
 public class ShadowController {
 
-    private final AtomicLong counter = new AtomicLong();
+    private final Logger logger = LoggerFactory.getLogger(ShadowController.class);
     //@Autowired
-    private DataService dataService = new DataService();
-    RestService restService = new RestService();
+    //private DataService dataService = new DataService();
+    @Autowired
+    private DataService dataService;
+    @Autowired
+    private RestService restService;
+    //RestService restService = new RestService();
 
     @RequestMapping(value = "/update/available/tags", method = RequestMethod.POST)
-    public void updateAvaliableTags(@RequestBody String availableTags){
+    public String updateAvaliableTags(@RequestBody String availableTags){
         JSONParser parser = new JSONParser();
         JSONObject jsonObject = null;
         JSONArray tagList = null;
         try {
             jsonObject = (JSONObject) parser.parse(availableTags);
             dataService.updateAvailableTags(jsonObject);
-            //tagList =  (JSONArray) parser.parse(jsonObject.get("tags").toString());
         }catch (Exception e){
-
+            logger.error("Exception updating tags : " + e);
+            return "{\"error\":\""+e+"\"}";
         }
+        return "{\"status\":\"updated\"}";
     }
 
-
     @RequestMapping(value = "/desired/tags", method = RequestMethod.POST)
-    public void desiredTags(@RequestBody String newTags){
+    public String desiredTags(@RequestBody String newTags){
         ObjectMapper mapper = new ObjectMapper();
         try {
             TagList tagList = mapper.readValue(newTags, TagList.class);
-            dataService.desiredTags(tagList);
-            restService.postToGetOPCData(tagList);
-            //restService.postToopcuaServiceUrl(newTags);
+            //dataService.desiredTags(tagList);
+            if(restService.postToGetOPCData(tagList))
+                dataService.desiredTags(tagList);
         }catch (Exception e){
-
+            logger.error("Error posting desired tags to OPC" + e);
+            return "{\"error\":\""+e+"\"}";
         }
+        return "{\"status\":\"updated\"}";
     }
 
-    @RequestMapping(value = "/get/available/tags", produces = "application/json")
+    @RequestMapping(value = "/reported/tags", method = RequestMethod.POST)
+    public String updateReportedTags(@RequestBody String reportedTags){
+        JSONParser parser = new JSONParser();
+        JSONObject jsonObject = null;
+        String ret = "";
+
+        try {
+            jsonObject = (JSONObject) parser.parse(reportedTags);
+            ret = dataService.updateReportedTags(jsonObject);
+        }catch (Exception e){
+            logger.error("Exception updating tags : " + e);
+            return "{\"error\":\""+e+"\"}";
+        }
+        //return "{\"status\":\"updated\"}";
+        return ret;
+    }
+
+    @RequestMapping(value = "/available/tags", produces = "application/json", method = RequestMethod.GET)
     public String getAvailableTagsByToken(@RequestParam(value="token") String token) {
         String jsonTagList = dataService.getAvailableTagsBytoken(token);
         return jsonTagList;
     }
 
-    @RequestMapping(value = "/available/tags", method = RequestMethod.DELETE)
-    public void deleteTagsByToken(@RequestParam(value="token") String token) throws SQLException{
-        dataService.deleteById(token);
-    }
+    /*@RequestMapping(value = "/available/tags", method = RequestMethod.DELETE)
+    public String deleteTagsByToken(@RequestParam(value="token") String token) throws SQLException{
+       return dataService.deleteById(token);
+    }*/
 
 }
-

--- a/Device-Management/src/main/java/org/thingsboard/device/shadow/controllers/ShadowController.java
+++ b/Device-Management/src/main/java/org/thingsboard/device/shadow/controllers/ShadowController.java
@@ -16,8 +16,6 @@ import org.thingsboard.device.shadow.models.TagList;
 import org.thingsboard.device.shadow.services.DataService;
 import org.thingsboard.device.shadow.services.RestService;
 
-import java.sql.SQLException;
-import java.util.concurrent.atomic.AtomicLong;
 
 
 @RestController

--- a/Device-Management/src/main/java/org/thingsboard/device/shadow/controllers/ShadowController.java
+++ b/Device-Management/src/main/java/org/thingsboard/device/shadow/controllers/ShadowController.java
@@ -24,13 +24,10 @@ import java.util.concurrent.atomic.AtomicLong;
 public class ShadowController {
 
     private final Logger logger = LoggerFactory.getLogger(ShadowController.class);
-    //@Autowired
-    //private DataService dataService = new DataService();
     @Autowired
     private DataService dataService;
     @Autowired
     private RestService restService;
-    //RestService restService = new RestService();
 
     @RequestMapping(value = "/update/available/tags", method = RequestMethod.POST)
     public String updateAvaliableTags(@RequestBody String availableTags){
@@ -66,17 +63,15 @@ public class ShadowController {
     public String updateReportedTags(@RequestBody String reportedTags){
         JSONParser parser = new JSONParser();
         JSONObject jsonObject = null;
-        String ret = "";
 
         try {
             jsonObject = (JSONObject) parser.parse(reportedTags);
-            ret = dataService.updateReportedTags(jsonObject);
+            dataService.updateReportedTags(jsonObject);
         }catch (Exception e){
             logger.error("Exception updating tags : " + e);
             return "{\"error\":\""+e+"\"}";
         }
-        //return "{\"status\":\"updated\"}";
-        return ret;
+        return "{\"status\":\"updated\"}";
     }
 
     @RequestMapping(value = "/available/tags", produces = "application/json", method = RequestMethod.GET)
@@ -84,10 +79,4 @@ public class ShadowController {
         String jsonTagList = dataService.getAvailableTagsBytoken(token);
         return jsonTagList;
     }
-
-    /*@RequestMapping(value = "/available/tags", method = RequestMethod.DELETE)
-    public String deleteTagsByToken(@RequestParam(value="token") String token) throws SQLException{
-       return dataService.deleteById(token);
-    }*/
-
 }

--- a/Device-Management/src/main/java/org/thingsboard/device/shadow/controllers/ShadowController.java
+++ b/Device-Management/src/main/java/org/thingsboard/device/shadow/controllers/ShadowController.java
@@ -1,0 +1,68 @@
+package org.thingsboard.device.shadow.controllers;
+
+/**
+ * Created by himanshu on 29/9/17.
+ */
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.json.simple.JSONArray;
+import org.json.simple.parser.JSONParser;
+import org.json.simple.JSONObject;
+import org.springframework.web.bind.annotation.*;
+import org.thingsboard.device.shadow.models.TagList;
+import org.thingsboard.device.shadow.services.DataService;
+import org.thingsboard.device.shadow.services.RestService;
+
+import java.sql.SQLException;
+import java.util.concurrent.atomic.AtomicLong;
+
+
+@RestController
+public class ShadowController {
+
+    private final AtomicLong counter = new AtomicLong();
+    //@Autowired
+    private DataService dataService = new DataService();
+    RestService restService = new RestService();
+
+    @RequestMapping(value = "/update/available/tags", method = RequestMethod.POST)
+    public void updateAvaliableTags(@RequestBody String availableTags){
+        JSONParser parser = new JSONParser();
+        JSONObject jsonObject = null;
+        JSONArray tagList = null;
+        try {
+            jsonObject = (JSONObject) parser.parse(availableTags);
+            dataService.updateAvailableTags(jsonObject);
+            //tagList =  (JSONArray) parser.parse(jsonObject.get("tags").toString());
+        }catch (Exception e){
+
+        }
+    }
+
+
+    @RequestMapping(value = "/desired/tags", method = RequestMethod.POST)
+    public void desiredTags(@RequestBody String newTags){
+        ObjectMapper mapper = new ObjectMapper();
+        try {
+            TagList tagList = mapper.readValue(newTags, TagList.class);
+            dataService.desiredTags(tagList);
+            restService.postToGetOPCData(tagList);
+            //restService.postToopcuaServiceUrl(newTags);
+        }catch (Exception e){
+
+        }
+    }
+
+    @RequestMapping(value = "/get/available/tags", produces = "application/json")
+    public String getAvailableTagsByToken(@RequestParam(value="token") String token) {
+        String jsonTagList = dataService.getAvailableTagsBytoken(token);
+        return jsonTagList;
+    }
+
+    @RequestMapping(value = "/available/tags", method = RequestMethod.DELETE)
+    public void deleteTagsByToken(@RequestParam(value="token") String token) throws SQLException{
+        dataService.deleteById(token);
+    }
+
+}
+

--- a/Device-Management/src/main/java/org/thingsboard/device/shadow/dao/DeviceShadowDao.java
+++ b/Device-Management/src/main/java/org/thingsboard/device/shadow/dao/DeviceShadowDao.java
@@ -13,6 +13,9 @@ public interface DeviceShadowDao {
     public void updateByDeviceToken(String token);
     public TagList getReportedTagsForDeviceToken(String token) throws SQLException;
     public void updateAvailableTags(DeviceShadow deviceShadow) throws SQLException;
-    public boolean deleteByToken(String deviceToken) throws SQLException;
+    //public boolean deleteByToken(String deviceToken) throws SQLException;
     public void updateDeviceState(TagList tagList) throws  SQLException;
+    public boolean checkIfTagExists(String token, String tag) throws SQLException;
+    public void updateReportedTags(String token, String tag) throws SQLException;
+    public TagList getAllTagsForDeviceToken(String token) throws SQLException;
 }

--- a/Device-Management/src/main/java/org/thingsboard/device/shadow/dao/DeviceShadowDao.java
+++ b/Device-Management/src/main/java/org/thingsboard/device/shadow/dao/DeviceShadowDao.java
@@ -1,0 +1,18 @@
+package org.thingsboard.device.shadow.dao;
+
+import org.thingsboard.device.shadow.models.DeviceShadow;
+import org.thingsboard.device.shadow.models.TagList;
+
+import java.sql.SQLException;
+
+/**
+ * Created by himanshu on 29/9/17.
+ */
+public interface DeviceShadowDao {
+    //@Query("select s from Student s where s.age <= ?")
+    public void updateByDeviceToken(String token);
+    public TagList getReportedTagsForDeviceToken(String token) throws SQLException;
+    public void updateAvailableTags(DeviceShadow deviceShadow) throws SQLException;
+    public boolean deleteByToken(String deviceToken) throws SQLException;
+    public void updateDeviceState(TagList tagList) throws  SQLException;
+}

--- a/Device-Management/src/main/java/org/thingsboard/device/shadow/dao/DeviceShadowDao.java
+++ b/Device-Management/src/main/java/org/thingsboard/device/shadow/dao/DeviceShadowDao.java
@@ -9,8 +9,6 @@ import java.sql.SQLException;
  * Created by himanshu on 29/9/17.
  */
 public interface DeviceShadowDao {
-    //@Query("select s from Student s where s.age <= ?")
-    public void updateByDeviceToken(String token);
     public TagList getReportedTagsForDeviceToken(String token) throws SQLException;
     public void updateAvailableTags(DeviceShadow deviceShadow) throws SQLException;
     //public boolean deleteByToken(String deviceToken) throws SQLException;

--- a/Device-Management/src/main/java/org/thingsboard/device/shadow/dao/DeviceShadowDao.java
+++ b/Device-Management/src/main/java/org/thingsboard/device/shadow/dao/DeviceShadowDao.java
@@ -9,11 +9,11 @@ import java.sql.SQLException;
  * Created by himanshu on 29/9/17.
  */
 public interface DeviceShadowDao {
-    public TagList getReportedTagsForDeviceToken(String token) throws SQLException;
-    public void updateAvailableTags(DeviceShadow deviceShadow) throws SQLException;
+    public String insertAvailableTags(DeviceShadow deviceShadow) throws SQLException;
+    public String updateAvailableTags(DeviceShadow deviceShadow) throws SQLException;
     //public boolean deleteByToken(String deviceToken) throws SQLException;
-    public void updateDeviceState(TagList tagList) throws  SQLException;
-    public boolean checkIfTagExists(String token, String tag) throws SQLException;
-    public void updateReportedTags(String token, String tag) throws SQLException;
-    public TagList getAllTagsForDeviceToken(String token) throws SQLException;
+    public void updateDeviceState(TagList tagList, String tagType) throws  SQLException;
+    public TagList getAvailableTagsForDevice(String deviceName) throws SQLException;
+    public boolean ifDeviceExists(String deviceName) throws SQLException;
+    public DeviceShadow getDeviceShadow(String deviceName) throws SQLException;
 }

--- a/Device-Management/src/main/java/org/thingsboard/device/shadow/dao/DeviceShadowDaoImp.java
+++ b/Device-Management/src/main/java/org/thingsboard/device/shadow/dao/DeviceShadowDaoImp.java
@@ -46,8 +46,6 @@ public class DeviceShadowDaoImp implements DeviceShadowDao {
     final String updateStateOfTag = "UPDATE device_shadow set desired='TRUE' where " +
             "DEVICETOKEN=? and TAGNAME=?";
 
-    final String deleteByToken = "delete from device_shadow where DEVICETOKEN=?";
-
     final String checkTagExistence = "SELECT count(*) FROM device_shadow WHERE " +
             "DEVICETOKEN=? and TAGNAME=?";
 
@@ -55,12 +53,8 @@ public class DeviceShadowDaoImp implements DeviceShadowDao {
             "DEVICETOKEN=? and TAGNAME=?";
 
     String dummyStr = "ns=2;s=Simulation Examples.Functions.";
-    public void updateByDeviceToken(String token){
-
-    }
 
     public void updateAvailableTags(DeviceShadow deviceShadow) throws SQLException{
-        logger.error("Here I am !");
         PreparedStatement ps = connection.prepareStatement(insertAvailableTags);
         ps.setString(1, deviceShadow.getDeviceToken());
         ps.setString(2, deviceShadow.getTagName());
@@ -134,7 +128,6 @@ public class DeviceShadowDaoImp implements DeviceShadowDao {
     }
 
     public void updateReportedTags(String token, String tag) throws SQLException{
-        logger.error("Here I am !");
         PreparedStatement ps = connection.prepareStatement(updateReportedTags);
         ps.setString(1, token);
         ps.setString(2, dummyStr+tag);

--- a/Device-Management/src/main/java/org/thingsboard/device/shadow/dao/DeviceShadowDaoImp.java
+++ b/Device-Management/src/main/java/org/thingsboard/device/shadow/dao/DeviceShadowDaoImp.java
@@ -1,0 +1,112 @@
+package org.thingsboard.device.shadow.dao;
+
+import org.apache.tomcat.jdbc.pool.DataSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.thingsboard.device.shadow.models.DeviceShadow;
+import org.thingsboard.device.shadow.models.TagList;
+
+import java.sql.*;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Created by himanshu on 29/9/17.
+ */
+
+public class DeviceShadowDaoImp implements DeviceShadowDao {
+
+    /*public void updateAvailableTags(DeviceShadow deviceShadow){
+        deviceShadowDao.save(deviceShadow);
+    }*/
+    Connection connection = null;
+    @Autowired
+    DataSource dataSource;
+
+    public DeviceShadowDaoImp(){
+        try {
+            String JDBC_DRIVER = "org.h2.Driver";
+            String DB_URL = "jdbc:h2:file:~/test2";
+            Class.forName(JDBC_DRIVER);
+            String USER = "sa";
+            String PASS = "";
+            connection = DriverManager.getConnection(DB_URL,USER,PASS);
+        }catch (Exception e){
+
+        }
+    }
+
+    final String insertReportedTags = "INSERT INTO device_shadow " +
+            "(deviceToken,tagName,desired,reported) VALUES (?, ?, ?, ?)";
+
+    final String fetchReportedTagsByToken = "SELECT TAGNAME from device_shadow where " +
+            "DEVICETOKEN = ? and " +
+            "REPORTED='TRUE'";
+
+    final String insertDesiredTags = "INSERT INTO device_shadow " +
+            "(deviceToken,tagName,desired,reported) VALUES (?, ?, ?, ?)";
+
+    final String updateStateOfTag = "UPDATE device_shadow set desired='TRUE' where " +
+            "DEVICETOKEN=? and TAGNAME=?";
+
+    final String deleteByToken = "delete from device_shadow where DEVICETOKEN=?";
+
+    public void updateByDeviceToken(String token){
+
+    }
+
+    public boolean deleteByToken(String deviceToken){
+        try {
+            PreparedStatement ps = connection.prepareStatement(deleteByToken);
+            ps.setString(1, deviceToken);
+            ps.execute();
+            ps.close();
+        }catch (SQLException e){
+            return false;
+        }
+        return true;
+    }
+
+    public void updateAvailableTags(DeviceShadow deviceShadow) throws SQLException{
+        PreparedStatement ps = connection.prepareStatement(insertReportedTags);
+        ps.setString(1, deviceShadow.getDeviceToken());
+        ps.setString(2, deviceShadow.getTagName());
+        ps.setBoolean(3, deviceShadow.getDesired());
+        ps.setBoolean(4, deviceShadow.getReported());
+        ps.executeUpdate();
+        ps.close();
+    }
+
+    public TagList getReportedTagsForDeviceToken(String token) throws SQLException{
+        List<String> repotedTags = new ArrayList<String>();
+        PreparedStatement ps = connection.prepareStatement(fetchReportedTagsByToken);
+        ps.setString(1,token);
+        ResultSet resultSet = ps.executeQuery();
+        TagList tagList = new TagList();
+        tagList.setToken(token);
+        while (resultSet.next()){
+            repotedTags.add(resultSet.getString(1));
+        }
+        tagList.setTags(repotedTags);
+        return tagList;
+    }
+
+    public void requestNewTags(DeviceShadow deviceShadow) throws SQLException{
+        PreparedStatement ps = connection.prepareStatement(insertDesiredTags);
+        ps.setString(1, deviceShadow.getDeviceToken());
+        ps.setString(2, deviceShadow.getTagName());
+        ps.setBoolean(3, deviceShadow.getDesired());
+        ps.setBoolean(4, deviceShadow.getReported());
+        ps.executeUpdate();
+        ps.close();
+    }
+
+    public void updateDeviceState(TagList tagList) throws  SQLException{
+        PreparedStatement ps = connection.prepareStatement(updateStateOfTag);
+        for (String tag : tagList.getTags()) {
+            ps.setString(1, tagList.getToken());
+            ps.setString(2, tag);
+            ps.executeUpdate();
+        }
+        ps.close();
+    }
+}

--- a/Device-Management/src/main/java/org/thingsboard/device/shadow/dao/DeviceShadowDaoImp.java
+++ b/Device-Management/src/main/java/org/thingsboard/device/shadow/dao/DeviceShadowDaoImp.java
@@ -2,10 +2,13 @@ package org.thingsboard.device.shadow.dao;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
+import org.thingsboard.device.shadow.components.ConfigProperties;
 import org.thingsboard.device.shadow.models.DeviceShadow;
 import org.thingsboard.device.shadow.models.TagList;
 
+import javax.annotation.PostConstruct;
 import java.sql.*;
 import java.util.ArrayList;
 import java.util.List;
@@ -17,17 +20,23 @@ import java.util.List;
 public class DeviceShadowDaoImp implements DeviceShadowDao {
 
     private Logger logger = LoggerFactory.getLogger(DeviceShadowDao.class);
-    Connection connection = null;
-    public DeviceShadowDaoImp(){
-        try {
-            String JDBC_DRIVER = "org.h2.Driver";
-            String DB_URL = "jdbc:h2:file:~/test2";
-            Class.forName(JDBC_DRIVER);
-            String USER = "sa";
-            String PASS = "";
-            connection = DriverManager.getConnection(DB_URL,USER,PASS);
-        }catch (Exception e){
 
+    @Autowired
+    private ConfigProperties configProperties;
+
+    Connection connection = null;
+
+    @PostConstruct
+    public void createDbConnection(){
+        try {
+            String DB_URL = configProperties.getDB_URL();
+            String USER = configProperties.getUSER();
+            String PASS = configProperties.getPASS();
+            connection = DriverManager.getConnection(DB_URL,USER,PASS);
+            logger.error("HMDC : Created h2 connection");
+        }catch (Exception e){
+            e.printStackTrace();
+            logger.error("Error in creating database connection " + e);
         }
     }
 
@@ -134,4 +143,5 @@ public class DeviceShadowDaoImp implements DeviceShadowDao {
         ps.executeUpdate();
         ps.close();
     }
+    
 }

--- a/Device-Management/src/main/java/org/thingsboard/device/shadow/dao/DeviceShadowDaoImp.java
+++ b/Device-Management/src/main/java/org/thingsboard/device/shadow/dao/DeviceShadowDaoImp.java
@@ -1,7 +1,8 @@
 package org.thingsboard.device.shadow.dao;
 
-import org.apache.tomcat.jdbc.pool.DataSource;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Repository;
 import org.thingsboard.device.shadow.models.DeviceShadow;
 import org.thingsboard.device.shadow.models.TagList;
 
@@ -12,16 +13,11 @@ import java.util.List;
 /**
  * Created by himanshu on 29/9/17.
  */
-
+@Repository("deviceShadowDao")
 public class DeviceShadowDaoImp implements DeviceShadowDao {
 
-    /*public void updateAvailableTags(DeviceShadow deviceShadow){
-        deviceShadowDao.save(deviceShadow);
-    }*/
+    private Logger logger = LoggerFactory.getLogger(DeviceShadowDao.class);
     Connection connection = null;
-    @Autowired
-    DataSource dataSource;
-
     public DeviceShadowDaoImp(){
         try {
             String JDBC_DRIVER = "org.h2.Driver";
@@ -35,12 +31,14 @@ public class DeviceShadowDaoImp implements DeviceShadowDao {
         }
     }
 
-    final String insertReportedTags = "INSERT INTO device_shadow " +
+    final String insertAvailableTags = "INSERT INTO device_shadow " +
             "(deviceToken,tagName,desired,reported) VALUES (?, ?, ?, ?)";
 
     final String fetchReportedTagsByToken = "SELECT TAGNAME from device_shadow where " +
             "DEVICETOKEN = ? and " +
             "REPORTED='TRUE'";
+    final String fetchAvailableTags = "SELECT TAGNAME from device_shadow where " +
+            "DEVICETOKEN = ?";
 
     final String insertDesiredTags = "INSERT INTO device_shadow " +
             "(deviceToken,tagName,desired,reported) VALUES (?, ?, ?, ?)";
@@ -50,24 +48,20 @@ public class DeviceShadowDaoImp implements DeviceShadowDao {
 
     final String deleteByToken = "delete from device_shadow where DEVICETOKEN=?";
 
+    final String checkTagExistence = "SELECT count(*) FROM device_shadow WHERE " +
+            "DEVICETOKEN=? and TAGNAME=?";
+
+    final String updateReportedTags = "UPDATE device_shadow set reported ='TRUE' where " +
+            "DEVICETOKEN=? and TAGNAME=?";
+
+    String dummyStr = "ns=2;s=Simulation Examples.Functions.";
     public void updateByDeviceToken(String token){
 
     }
 
-    public boolean deleteByToken(String deviceToken){
-        try {
-            PreparedStatement ps = connection.prepareStatement(deleteByToken);
-            ps.setString(1, deviceToken);
-            ps.execute();
-            ps.close();
-        }catch (SQLException e){
-            return false;
-        }
-        return true;
-    }
-
     public void updateAvailableTags(DeviceShadow deviceShadow) throws SQLException{
-        PreparedStatement ps = connection.prepareStatement(insertReportedTags);
+        logger.error("Here I am !");
+        PreparedStatement ps = connection.prepareStatement(insertAvailableTags);
         ps.setString(1, deviceShadow.getDeviceToken());
         ps.setString(2, deviceShadow.getTagName());
         ps.setBoolean(3, deviceShadow.getDesired());
@@ -79,6 +73,20 @@ public class DeviceShadowDaoImp implements DeviceShadowDao {
     public TagList getReportedTagsForDeviceToken(String token) throws SQLException{
         List<String> repotedTags = new ArrayList<String>();
         PreparedStatement ps = connection.prepareStatement(fetchReportedTagsByToken);
+        ps.setString(1,token);
+        ResultSet resultSet = ps.executeQuery();
+        TagList tagList = new TagList();
+        tagList.setToken(token);
+        while (resultSet.next()){
+            repotedTags.add(resultSet.getString(1));
+        }
+        tagList.setTags(repotedTags);
+        return tagList;
+    }
+
+    public TagList getAllTagsForDeviceToken(String token) throws SQLException{
+        List<String> repotedTags = new ArrayList<String>();
+        PreparedStatement ps = connection.prepareStatement(fetchAvailableTags);
         ps.setString(1,token);
         ResultSet resultSet = ps.executeQuery();
         TagList tagList = new TagList();
@@ -107,6 +115,30 @@ public class DeviceShadowDaoImp implements DeviceShadowDao {
             ps.setString(2, tag);
             ps.executeUpdate();
         }
+        ps.close();
+    }
+
+    public boolean checkIfTagExists(String token, String tag) throws SQLException{
+        PreparedStatement ps = connection.prepareStatement(checkTagExistence);
+        ps.setString(1, token);
+        ps.setString(2, tag);
+        ResultSet resultSet = ps.executeQuery();
+        if (resultSet.next()) {
+            if(resultSet.getInt(1) > 0){
+                logger.debug("Tag already present");
+                return true;
+            }
+        }
+        logger.debug("Tag Initially not present");
+        return false;
+    }
+
+    public void updateReportedTags(String token, String tag) throws SQLException{
+        logger.error("Here I am !");
+        PreparedStatement ps = connection.prepareStatement(updateReportedTags);
+        ps.setString(1, token);
+        ps.setString(2, dummyStr+tag);
+        ps.executeUpdate();
         ps.close();
     }
 }

--- a/Device-Management/src/main/java/org/thingsboard/device/shadow/dao/DeviceShadowDaoImp.java
+++ b/Device-Management/src/main/java/org/thingsboard/device/shadow/dao/DeviceShadowDaoImp.java
@@ -10,16 +10,14 @@ import org.thingsboard.device.shadow.models.TagList;
 
 import javax.annotation.PostConstruct;
 import java.sql.*;
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
-/**
- * Created by himanshu on 29/9/17.
- */
 @Repository("deviceShadowDao")
 public class DeviceShadowDaoImp implements DeviceShadowDao {
 
     private Logger logger = LoggerFactory.getLogger(DeviceShadowDao.class);
+    private String shadowTable = "DEVICE_SHADOW";
 
     @Autowired
     private ConfigProperties configProperties;
@@ -33,115 +31,130 @@ public class DeviceShadowDaoImp implements DeviceShadowDao {
             String USER = configProperties.getUSER();
             String PASS = configProperties.getPASS();
             connection = DriverManager.getConnection(DB_URL,USER,PASS);
-            logger.error("HMDC : Created h2 connection");
         }catch (Exception e){
             e.printStackTrace();
             logger.error("Error in creating database connection " + e);
         }
     }
 
-    final String insertAvailableTags = "INSERT INTO device_shadow " +
-            "(deviceToken,tagName,desired,reported) VALUES (?, ?, ?, ?)";
+    final String insertAvailableTags = "INSERT INTO " + shadowTable +
+            " (deviceName,availableTags,desiredTags,reportedTags) VALUES (?, ?, ?, ?)";
 
-    final String fetchReportedTagsByToken = "SELECT TAGNAME from device_shadow where " +
-            "DEVICETOKEN = ? and " +
-            "REPORTED='TRUE'";
-    final String fetchAvailableTags = "SELECT TAGNAME from device_shadow where " +
-            "DEVICETOKEN = ?";
+    final String updateAvailableTags = "UPDATE " + shadowTable + " set availableTags=? where " +
+            "DEVICENAME=?";
 
-    final String insertDesiredTags = "INSERT INTO device_shadow " +
-            "(deviceToken,tagName,desired,reported) VALUES (?, ?, ?, ?)";
+    final String fetchAvailableTags = "SELECT AVAILABLETAGS from "+ shadowTable +" where " +
+            "DEVICENAME = ?";
 
-    final String updateStateOfTag = "UPDATE device_shadow set desired='TRUE' where " +
-            "DEVICETOKEN=? and TAGNAME=?";
+    final String updateDesiredTags = "UPDATE " + shadowTable + " set DESIREDTAGS=? where " +
+            "DEVICENAME=?";
 
-    final String checkTagExistence = "SELECT count(*) FROM device_shadow WHERE " +
-            "DEVICETOKEN=? and TAGNAME=?";
+    final String updateReportedTags = "UPDATE " + shadowTable + " set REPORTEDTAGS=? where " +
+            "DEVICENAME=?";
 
-    final String updateReportedTags = "UPDATE device_shadow set reported ='TRUE' where " +
-            "DEVICETOKEN=? and TAGNAME=?";
+    final String checkDeviceExistence = "SELECT count(*) FROM " + shadowTable + " WHERE "
+            + "DEVICENAME=?";
 
-    String dummyStr = "ns=2;s=Simulation Examples.Functions.";
+    final String getDeviceShadow = "SELECT * from " + shadowTable + " WHERE DEVICENAME=?";
 
-    public void updateAvailableTags(DeviceShadow deviceShadow) throws SQLException{
+
+    public String insertAvailableTags(DeviceShadow deviceShadow) throws SQLException{
         PreparedStatement ps = connection.prepareStatement(insertAvailableTags);
-        ps.setString(1, deviceShadow.getDeviceToken());
-        ps.setString(2, deviceShadow.getTagName());
-        ps.setBoolean(3, deviceShadow.getDesired());
-        ps.setBoolean(4, deviceShadow.getReported());
+        ps.setString(1, deviceShadow.getDeviceName());
+        ps.setString(2, deviceShadow.getAvailableTags());
+        ps.setString(3, deviceShadow.getDesiredTags());
+        ps.setString(4, deviceShadow.getReportedTags());
         ps.executeUpdate();
         ps.close();
+        return "{\"status\" : \"updated\" }";
     }
 
-    public TagList getReportedTagsForDeviceToken(String token) throws SQLException{
-        List<String> repotedTags = new ArrayList<String>();
-        PreparedStatement ps = connection.prepareStatement(fetchReportedTagsByToken);
-        ps.setString(1,token);
-        ResultSet resultSet = ps.executeQuery();
-        TagList tagList = new TagList();
-        tagList.setToken(token);
-        while (resultSet.next()){
-            repotedTags.add(resultSet.getString(1));
+    public String updateAvailableTags(DeviceShadow deviceShadow) throws SQLException{
+        TagList availableTagList = getAvailableTagsForDevice(deviceShadow.getDeviceName());
+        String status = "";
+        String avaiableTagListStr = "";
+        for (String tag: availableTagList.getTags()) {
+            avaiableTagListStr = avaiableTagListStr + tag + ",";
         }
-        tagList.setTags(repotedTags);
-        return tagList;
-    }
-
-    public TagList getAllTagsForDeviceToken(String token) throws SQLException{
-        List<String> repotedTags = new ArrayList<String>();
-        PreparedStatement ps = connection.prepareStatement(fetchAvailableTags);
-        ps.setString(1,token);
-        ResultSet resultSet = ps.executeQuery();
-        TagList tagList = new TagList();
-        tagList.setToken(token);
-        while (resultSet.next()){
-            repotedTags.add(resultSet.getString(1));
-        }
-        tagList.setTags(repotedTags);
-        return tagList;
-    }
-
-    public void requestNewTags(DeviceShadow deviceShadow) throws SQLException{
-        PreparedStatement ps = connection.prepareStatement(insertDesiredTags);
-        ps.setString(1, deviceShadow.getDeviceToken());
-        ps.setString(2, deviceShadow.getTagName());
-        ps.setBoolean(3, deviceShadow.getDesired());
-        ps.setBoolean(4, deviceShadow.getReported());
-        ps.executeUpdate();
-        ps.close();
-    }
-
-    public void updateDeviceState(TagList tagList) throws  SQLException{
-        PreparedStatement ps = connection.prepareStatement(updateStateOfTag);
-        for (String tag : tagList.getTags()) {
-            ps.setString(1, tagList.getToken());
-            ps.setString(2, tag);
+        if(!avaiableTagListStr.contains(deviceShadow.getAvailableTags())) {
+            PreparedStatement ps = connection.prepareStatement(updateAvailableTags);
+            ps.setString(2, deviceShadow.getDeviceName());
+            String setStr = avaiableTagListStr +
+                    deviceShadow.getAvailableTags();
+            ps.setString(1, setStr);
             ps.executeUpdate();
+            ps.close();
+            status = "{\"status\" : \"updated\"}";
+        }else {
+            status = "{\"error\" : \"Duplicate tag\"}";
         }
+        return status;
+    }
+
+    public TagList getAvailableTagsForDevice(String device) throws SQLException{
+        PreparedStatement ps = connection.prepareStatement(fetchAvailableTags);
+        ps.setString(1,device);
+        ResultSet resultSet = ps.executeQuery();
+        TagList tagList = new TagList();
+        tagList.setDeviceName(device);
+        if (resultSet.next()){
+            String availableTags = resultSet.getString(1);//.replaceAll("/\\[.*?\\]/","");
+            String[] list = availableTags.split(",");
+            List<String> availableTagsList = Arrays.asList(list);
+            //List<String> availableTagsList = new ArrayList<String>(Arrays.asList(availableTags.split(",")));
+            tagList.setTags(availableTagsList);
+        }
+        return tagList;
+    }
+
+    public void updateDeviceState(TagList tagList, String tagType) throws  SQLException{
+        logger.debug("tagType" + tagType);
+        logger.debug("tagList" + tagList.getTags());
+        PreparedStatement ps = null;
+        if(tagType.contentEquals("desired"))
+            ps = connection.prepareStatement(updateDesiredTags);
+        else if(tagType.contentEquals("reported"))
+            ps = connection.prepareStatement(updateReportedTags);
+        String tags = "";
+        for (String tag : tagList.getTags()) {
+            tags = tags + tag + ",";
+        }
+        tags = tags.substring(0,tags.length() - 1);
+        ps.setString(1, tags);
+        ps.setString(2, tagList.getDeviceName());
+        ps.executeUpdate();
         ps.close();
     }
 
-    public boolean checkIfTagExists(String token, String tag) throws SQLException{
-        PreparedStatement ps = connection.prepareStatement(checkTagExistence);
-        ps.setString(1, token);
-        ps.setString(2, tag);
+    public boolean ifDeviceExists(String deviceName) throws SQLException{
+        PreparedStatement ps = connection.prepareStatement(checkDeviceExistence);
+        ps.setString(1, deviceName);
         ResultSet resultSet = ps.executeQuery();
         if (resultSet.next()) {
             if(resultSet.getInt(1) > 0){
-                logger.debug("Tag already present");
+                logger.debug("Device already present");
                 return true;
             }
         }
-        logger.debug("Tag Initially not present");
+        logger.debug("Device Initially not present");
         return false;
     }
 
-    public void updateReportedTags(String token, String tag) throws SQLException{
-        PreparedStatement ps = connection.prepareStatement(updateReportedTags);
-        ps.setString(1, token);
-        ps.setString(2, dummyStr+tag);
-        ps.executeUpdate();
-        ps.close();
+    public DeviceShadow getDeviceShadow(String device) throws SQLException{
+        PreparedStatement ps = connection.prepareStatement(getDeviceShadow);
+        DeviceShadow deviceShadow = new DeviceShadow(device,"","","");
+        ps.setString(1,device);
+        ResultSet resultSet = ps.executeQuery();
+        if (resultSet.next()){
+            String availableTags = resultSet.getString(2);
+            String reportedTags = resultSet.getString(3);
+            String desiredTags = resultSet.getString(4);
+            deviceShadow.setDeviceName(device);
+            deviceShadow.setAvailableTags(availableTags);
+            deviceShadow.setDesiredTags(desiredTags);
+            deviceShadow.setReportedTags(reportedTags);
+        }
+        return deviceShadow;
     }
     
 }

--- a/Device-Management/src/main/java/org/thingsboard/device/shadow/models/DeviceShadow.java
+++ b/Device-Management/src/main/java/org/thingsboard/device/shadow/models/DeviceShadow.java
@@ -1,0 +1,42 @@
+package org.thingsboard.device.shadow.models;
+
+import javax.persistence.*;
+
+/**
+ * Created by himanshu on 29/9/17.
+ */
+
+public class DeviceShadow {
+
+    /*@Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private long id;*/
+    private String deviceToken;
+    private String tagName;
+    private Boolean desired;
+    private Boolean reported;
+
+    public DeviceShadow(String deviceToken, String tagName, Boolean desired, Boolean reported){
+        this.deviceToken = deviceToken;
+        this.tagName = tagName;
+        this.desired = desired;
+        this.reported = reported;
+    }
+
+
+    public String getDeviceToken() {
+        return deviceToken;
+    }
+
+    public String getTagName() {
+        return tagName;
+    }
+
+    public Boolean getDesired() {
+        return desired;
+    }
+
+    public Boolean getReported() {
+        return reported;
+    }
+}

--- a/Device-Management/src/main/java/org/thingsboard/device/shadow/models/DeviceShadow.java
+++ b/Device-Management/src/main/java/org/thingsboard/device/shadow/models/DeviceShadow.java
@@ -1,42 +1,54 @@
 package org.thingsboard.device.shadow.models;
 
-import javax.persistence.*;
+import java.util.List;
 
 /**
- * Created by himanshu on 29/9/17.
+ * Created by himanshu on 30/10/17.
  */
-
 public class DeviceShadow {
+    private String deviceName;
+    private String availableTags;
+    private String desiredTags;
+    private String reportedTags;
 
-    /*@Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
-    private long id;*/
-    private String deviceToken;
-    private String tagName;
-    private Boolean desired;
-    private Boolean reported;
-
-    public DeviceShadow(String deviceToken, String tagName, Boolean desired, Boolean reported){
-        this.deviceToken = deviceToken;
-        this.tagName = tagName;
-        this.desired = desired;
-        this.reported = reported;
+    public DeviceShadow(String deviceName, String availableTags, String desiredTags,
+                        String reportedTags){
+        this.deviceName = deviceName;
+        this.availableTags = availableTags;
+        this.desiredTags = desiredTags;
+        this.reportedTags = reportedTags;
     }
 
-
-    public String getDeviceToken() {
-        return deviceToken;
+    public String getDeviceName() {
+        return deviceName;
     }
 
-    public String getTagName() {
-        return tagName;
+    public void setDeviceName(String deviceName) {
+        this.deviceName = deviceName;
     }
 
-    public Boolean getDesired() {
-        return desired;
+    public void setAvailableTags(String availableTags) {
+        this.availableTags = availableTags;
     }
 
-    public Boolean getReported() {
-        return reported;
+    public void setDesiredTags(String desiredTags) {
+        this.desiredTags = desiredTags;
     }
+
+    public void setReportedTags(String reportedTags) {
+        this.reportedTags = reportedTags;
+    }
+
+    public String getAvailableTags() {
+        return availableTags;
+    }
+
+    public String getDesiredTags() {
+        return desiredTags;
+    }
+
+    public String getReportedTags() {
+        return reportedTags;
+    }
+
 }

--- a/Device-Management/src/main/java/org/thingsboard/device/shadow/models/TagList.java
+++ b/Device-Management/src/main/java/org/thingsboard/device/shadow/models/TagList.java
@@ -2,19 +2,16 @@ package org.thingsboard.device.shadow.models;
 
 import java.util.List;
 
-/**
- * Created by himanshu on 4/10/17.
- */
 public class TagList {
-    private String token;
+    private String deviceName;
     private List<String> tags;
 
-    public void setToken(String token) {
-        this.token = token;
+    public void setDeviceName(String deviceName) {
+        this.deviceName = deviceName;
     }
 
-    public String getToken() {
-        return token;
+    public String getDeviceName() {
+        return deviceName;
     }
 
     public void setTags(List<String> tags) {

--- a/Device-Management/src/main/java/org/thingsboard/device/shadow/models/TagList.java
+++ b/Device-Management/src/main/java/org/thingsboard/device/shadow/models/TagList.java
@@ -1,0 +1,27 @@
+package org.thingsboard.device.shadow.models;
+
+import java.util.List;
+
+/**
+ * Created by himanshu on 4/10/17.
+ */
+public class TagList {
+    private String token;
+    private List<String> tags;
+
+    public void setToken(String token) {
+        this.token = token;
+    }
+
+    public String getToken() {
+        return token;
+    }
+
+    public void setTags(List<String> tags) {
+        this.tags = tags;
+    }
+
+    public List<String> getTags() {
+        return tags;
+    }
+}

--- a/Device-Management/src/main/java/org/thingsboard/device/shadow/services/DataService.java
+++ b/Device-Management/src/main/java/org/thingsboard/device/shadow/services/DataService.java
@@ -54,14 +54,7 @@ public class DataService {
                 logger.error("Error updating availableTags : " + e);
             }
         }
-        /*else {
-            try {
-                shadowDao.deleteByToken(deviceToken);
-            }catch (SQLException e){
-                logger.error("Error in deleting tags before updation : " + e);
-            }
-        }*/
-        //DeviceShadow deviceShadow = new DeviceShadow();
+
     }
 
     public void desiredTags(TagList tagList)throws Exception{
@@ -82,12 +75,11 @@ public class DataService {
         return jsontTagList;
     }
 
-    public String updateReportedTags(JSONObject jsonObject){
+    public void updateReportedTags(JSONObject jsonObject){
         String reportedTags = jsonObject.get("values").toString();
         String token = jsonObject.get("token").toString();
         JSONParser parser = new JSONParser();
         JSONObject jsonObjectTagsOnly = null;
-        String ret = "";
         try {
             jsonObjectTagsOnly = (JSONObject) parser.parse(reportedTags);
             Set<String> keys = jsonObjectTagsOnly.keySet();
@@ -98,17 +90,6 @@ public class DataService {
         }catch (Exception e){
             logger.error("Exception updating tags : " + e);
         }
-        return ret;
     }
-    /*public String deleteById(String token)throws SQLException{
-        if(shadowDao.deleteByToken(token)){
-            try {
-                restService.postToThingsBoard(token);
-            }catch (Exception e){
-                logger.error("Error deleting attributes in thingsboard : " + e);
-                return "{\"error\": \"" + e + "\"}";
-            }
-        }
-        return "\"status\":\"deleted\"";
-    }*/
+
 }

--- a/Device-Management/src/main/java/org/thingsboard/device/shadow/services/DataService.java
+++ b/Device-Management/src/main/java/org/thingsboard/device/shadow/services/DataService.java
@@ -1,0 +1,89 @@
+package org.thingsboard.device.shadow.services;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.thingsboard.device.shadow.dao.DeviceShadowDao;
+import org.thingsboard.device.shadow.dao.DeviceShadowDaoImp;
+import org.thingsboard.device.shadow.models.DeviceShadow;
+import org.thingsboard.device.shadow.models.TagList;
+
+import java.sql.SQLException;
+
+
+/**
+ * Created by himanshu on 3/10/17.
+ */
+public class DataService {
+
+    Logger logger = LoggerFactory.getLogger(DataService.class);
+    DeviceShadowDao shadowDao = new DeviceShadowDaoImp();
+    RestService restService = new RestService();
+
+    public JSONObject updateAvailableTags(JSONObject availableTags) throws Exception{
+        JSONParser parser = new JSONParser();
+        String tagList = null;
+        String deviceToken = "";
+
+        try {
+            //tagList = (JSONArray) parser.parse(availableTags.get("tags").toString());
+            deviceToken = availableTags.get("token").toString();
+        }catch (Exception e){
+
+        }
+        if (!availableTags.get("tags").toString().contentEquals("")) {
+            //Spliting the tagList.
+            tagList = availableTags.get("tags").toString();
+            String[] list = tagList.split(",");
+            try {
+                shadowDao.deleteByToken(deviceToken);
+                for (int itr = 0; itr < list.length; itr++) {
+                    DeviceShadow deviceShadow = new DeviceShadow(deviceToken, list[itr], false, true);
+                    shadowDao.updateAvailableTags(deviceShadow);
+                }
+            } catch (Exception SQLException) {
+
+            }
+        }
+        else {
+            try {
+                shadowDao.deleteByToken(deviceToken);
+            }catch (SQLException e){
+
+            }
+        }
+        //DeviceShadow deviceShadow = new DeviceShadow();
+        return availableTags;
+    }
+
+    public void desiredTags(TagList tagList)throws Exception{
+        logger.error("here I am! desired tags");
+        shadowDao.updateDeviceState(tagList);
+    }
+    public String getAvailableTagsBytoken(String token){
+        TagList tagList = null;
+        String jsontTagList = "";
+        try {
+            tagList = shadowDao.getReportedTagsForDeviceToken(token);
+            ObjectMapper mapper = new ObjectMapper();
+            jsontTagList = mapper.writeValueAsString(tagList);
+        }catch (Exception e){
+
+        }
+        //JSONObject tagListJson = new JSONObject(tagList.getClass());
+        return jsontTagList;
+    }
+
+    public void deleteById(String token)throws SQLException{
+        if(shadowDao.deleteByToken(token)){
+            try {
+                restService.postToThingsBoard(token);
+            }catch (Exception e){
+
+            }
+        }
+    }
+
+}

--- a/Device-Management/src/main/java/org/thingsboard/device/shadow/services/RestService.java
+++ b/Device-Management/src/main/java/org/thingsboard/device/shadow/services/RestService.java
@@ -2,10 +2,6 @@ package org.thingsboard.device.shadow.services;
 
 
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpPost;
@@ -25,7 +21,7 @@ public class RestService {
 
         String tagsStr = createTagStr(tagList);
         Boolean status = true;
-        logger.error("opca msg" + tagsStr);
+        logger.debug("opca msg\n" + tagsStr);
         HttpPost postRequest = new HttpPost(getOpcDataUrl);
         StringEntity input = new StringEntity(tagsStr);
         input.setContentType("text/plain");
@@ -36,16 +32,14 @@ public class RestService {
 
         if (response.getStatusLine().getStatusCode() != 200) {
             status = false;
-            //throw new RuntimeException("Failed : HTTP error code : "
-                    //+ response.getStatusLine().getStatusCode());
         }
         return status;
     }
 
     public String createTagStr(TagList tagList){
-        String tagsStr = "";
+        String tagsStr = tagList.getDeviceName() + "\n";
         for (int i = 0; i < tagList.getTags().size(); i++){
-            tagsStr = tagsStr + tagList.getTags().get(i) + "\n";
+            tagsStr = tagsStr + tagList.getDeviceName() + "." + tagList.getTags().get(i) + "\n";
         }
         return tagsStr;
     }

--- a/Device-Management/src/main/java/org/thingsboard/device/shadow/services/RestService.java
+++ b/Device-Management/src/main/java/org/thingsboard/device/shadow/services/RestService.java
@@ -1,0 +1,82 @@
+package org.thingsboard.device.shadow.services;
+
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.thingsboard.device.shadow.models.TagList;
+
+public class RestService {
+    Logger logger = LoggerFactory.getLogger(RestService.class);
+    private String tbURL = "http://localhost:8080/api/v1/";
+    private String getOpcDataUrl = "http://localhost:8088/contentListener";
+
+    public void postToThingsBoard(String token) throws IOException, RuntimeException {
+
+        String tbAttributesJson = createTBArributeRequest(token);
+        logger.debug("Attribute Json " + tbAttributesJson);
+        HttpPost postRequest = new HttpPost(tbURL + token + "/attributes");
+        StringEntity input = new StringEntity(tbAttributesJson);
+        input.setContentType("application/json");
+        postRequest.setEntity(input);
+
+        HttpClient httpClient = HttpClientBuilder.create().build();
+        HttpResponse response = httpClient.execute(postRequest);
+
+        if (response.getStatusLine().getStatusCode() != 200) {
+            throw new RuntimeException("Failed : HTTP error code : "
+                    + response.getStatusLine().getStatusCode());
+        }
+        logger.error("Here I am!");
+    }
+
+    public String createTBArributeRequest(String token){
+        Map<String,String> tbAttributes = new HashMap<String, String>();
+        tbAttributes.put("token",token);
+        tbAttributes.put("tags","");
+        ObjectMapper mapper = new ObjectMapper();
+        String tbAttributesJson="";
+        try {
+            tbAttributesJson = mapper.writeValueAsString(tbAttributes);
+        }catch (Exception e){
+
+        }
+        logger.error("Here I am!");
+        return tbAttributesJson;
+    }
+
+    public void postToGetOPCData(TagList tagList) throws IOException, RuntimeException {
+
+        String tagsStr = createTagStr(tagList);
+        logger.error("opca msg" + tagsStr);
+        HttpPost postRequest = new HttpPost(getOpcDataUrl);
+        StringEntity input = new StringEntity(tagsStr);
+        input.setContentType("text/plain");
+        postRequest.setEntity(input);
+
+        HttpClient httpClient = HttpClientBuilder.create().build();
+        HttpResponse response = httpClient.execute(postRequest);
+
+        if (response.getStatusLine().getStatusCode() != 200) {
+            throw new RuntimeException("Failed : HTTP error code : "
+                    + response.getStatusLine().getStatusCode());
+        }
+    }
+
+    public String createTagStr(TagList tagList){
+        String tagsStr = "";
+        for (int i = 0; i < tagList.getTags().size(); i++){
+            tagsStr = tagsStr + tagList.getTags().get(i) + "\n";
+        }
+        return tagsStr;
+    }
+}

--- a/Device-Management/src/main/java/org/thingsboard/device/shadow/services/RestService.java
+++ b/Device-Management/src/main/java/org/thingsboard/device/shadow/services/RestService.java
@@ -13,13 +13,16 @@ import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
 import org.thingsboard.device.shadow.models.TagList;
 
+@Service("restService")
 public class RestService {
     Logger logger = LoggerFactory.getLogger(RestService.class);
     private String tbURL = "http://localhost:8080/api/v1/";
     private String getOpcDataUrl = "http://localhost:8088/contentListener";
 
+    //Not used.
     public void postToThingsBoard(String token) throws IOException, RuntimeException {
 
         String tbAttributesJson = createTBArributeRequest(token);
@@ -54,7 +57,7 @@ public class RestService {
         return tbAttributesJson;
     }
 
-    public void postToGetOPCData(TagList tagList) throws IOException, RuntimeException {
+    public boolean postToGetOPCData(TagList tagList) throws IOException, RuntimeException {
 
         String tagsStr = createTagStr(tagList);
         logger.error("opca msg" + tagsStr);
@@ -69,7 +72,9 @@ public class RestService {
         if (response.getStatusLine().getStatusCode() != 200) {
             throw new RuntimeException("Failed : HTTP error code : "
                     + response.getStatusLine().getStatusCode());
+            //return false;
         }
+        return true;
     }
 
     public String createTagStr(TagList tagList){

--- a/Device-Management/src/main/java/org/thingsboard/device/shadow/services/RestService.java
+++ b/Device-Management/src/main/java/org/thingsboard/device/shadow/services/RestService.java
@@ -19,47 +19,12 @@ import org.thingsboard.device.shadow.models.TagList;
 @Service("restService")
 public class RestService {
     Logger logger = LoggerFactory.getLogger(RestService.class);
-    private String tbURL = "http://localhost:8080/api/v1/";
     private String getOpcDataUrl = "http://localhost:8088/contentListener";
-
-    //Not used.
-    public void postToThingsBoard(String token) throws IOException, RuntimeException {
-
-        String tbAttributesJson = createTBArributeRequest(token);
-        logger.debug("Attribute Json " + tbAttributesJson);
-        HttpPost postRequest = new HttpPost(tbURL + token + "/attributes");
-        StringEntity input = new StringEntity(tbAttributesJson);
-        input.setContentType("application/json");
-        postRequest.setEntity(input);
-
-        HttpClient httpClient = HttpClientBuilder.create().build();
-        HttpResponse response = httpClient.execute(postRequest);
-
-        if (response.getStatusLine().getStatusCode() != 200) {
-            throw new RuntimeException("Failed : HTTP error code : "
-                    + response.getStatusLine().getStatusCode());
-        }
-        logger.error("Here I am!");
-    }
-
-    public String createTBArributeRequest(String token){
-        Map<String,String> tbAttributes = new HashMap<String, String>();
-        tbAttributes.put("token",token);
-        tbAttributes.put("tags","");
-        ObjectMapper mapper = new ObjectMapper();
-        String tbAttributesJson="";
-        try {
-            tbAttributesJson = mapper.writeValueAsString(tbAttributes);
-        }catch (Exception e){
-
-        }
-        logger.error("Here I am!");
-        return tbAttributesJson;
-    }
 
     public boolean postToGetOPCData(TagList tagList) throws IOException, RuntimeException {
 
         String tagsStr = createTagStr(tagList);
+        Boolean status = true;
         logger.error("opca msg" + tagsStr);
         HttpPost postRequest = new HttpPost(getOpcDataUrl);
         StringEntity input = new StringEntity(tagsStr);
@@ -70,11 +35,11 @@ public class RestService {
         HttpResponse response = httpClient.execute(postRequest);
 
         if (response.getStatusLine().getStatusCode() != 200) {
-            throw new RuntimeException("Failed : HTTP error code : "
-                    + response.getStatusLine().getStatusCode());
-            //return false;
+            status = false;
+            //throw new RuntimeException("Failed : HTTP error code : "
+                    //+ response.getStatusLine().getStatusCode());
         }
-        return true;
+        return status;
     }
 
     public String createTagStr(TagList tagList){

--- a/Device-Management/src/main/resources/application.properties
+++ b/Device-Management/src/main/resources/application.properties
@@ -8,8 +8,8 @@ spring.datasource.url=jdbc:h2:file:~/test2;DB_CLOSE_ON_EXIT=FALSE
 spring.datasource.username=sa
 spring.datasource.password=
 spring.datasource.driverClassName=org.h2.Driver
-spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+#spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
 #spring.datasource.initialize=true
 #spring.jpa.hibernate.ddl-auto = update
-spring.jpa.hibernate.show-sql=false
+#spring.jpa.hibernate.show-sql=false
 logging.level.org.springframework.web=DEBUG

--- a/Device-Management/src/main/resources/application.properties
+++ b/Device-Management/src/main/resources/application.properties
@@ -1,0 +1,15 @@
+server.port = 8090
+#spring.jpa.hibernate.ddl-auto=none
+java.version=1.8
+spring.h2.console.enabled=true
+spring.h2.console.path=/h2_console
+spring.datasource.platform=h2
+spring.datasource.url=jdbc:h2:file:~/test2;DB_CLOSE_ON_EXIT=FALSE
+spring.datasource.username=sa
+spring.datasource.password=
+spring.datasource.driverClassName=org.h2.Driver
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+#spring.datasource.initialize=true
+#spring.jpa.hibernate.ddl-auto = update
+spring.jpa.hibernate.show-sql=false
+logging.level.org.springframework.web=DEBUG

--- a/Device-Management/src/main/resources/schema-h2.sql
+++ b/Device-Management/src/main/resources/schema-h2.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS DEVICE_SHADOW (
+  deviceToken varchar,
+  tagName varchar,
+  reported boolean,
+  desired boolean,
+  CONSTRAINT PK_DEVICE_SHADOW PRIMARY KEY (deviceToken, tagName)
+ );

--- a/Device-Management/src/main/resources/schema-h2.sql
+++ b/Device-Management/src/main/resources/schema-h2.sql
@@ -1,7 +1,7 @@
 CREATE TABLE IF NOT EXISTS DEVICE_SHADOW (
-  deviceToken varchar,
-  tagName varchar,
-  reported boolean,
-  desired boolean,
-  CONSTRAINT PK_DEVICE_SHADOW PRIMARY KEY (deviceToken, tagName)
+  deviceName varchar,
+  availableTags varchar,
+  reportedTags varchar,
+  desiredTags varchar,
+  CONSTRAINT PK_DEVICE_SHADOW PRIMARY KEY (deviceName)
  );

--- a/Device-Management/src/test/java/org/thingsboard/device/shadow/ShadowControllerTest.java
+++ b/Device-Management/src/test/java/org/thingsboard/device/shadow/ShadowControllerTest.java
@@ -34,13 +34,23 @@ public class ShadowControllerTest {
 
     @Test
     public void shadowControllerShouldReturnUpdateStatus() throws Exception {
-        String json = "{\"token\":\"abc\",\"tags\":\"temp,pressure\"}";
+        String json = "{\"deviceName\":\"abc\",\"tags\":\"temp\"}";
         //String response = "{\"status\":\"updated\"}";
         this.mockMvc.perform(post("/update/available/tags").contentType(
                 MediaType.APPLICATION_JSON).content(json)).andExpect(
                 status().isOk())
                 .andDo(print()).andExpect(status().isOk())
                 .andExpect(jsonPath("$.status").value("updated"));
+    }
+
+    @Test
+    public void shadowControllerShouldReturnDuplicateErrorStatus() throws Exception {
+        String json = "{\"deviceName\":\"abc\",\"tags\":\"temp\"}";
+        this.mockMvc.perform(post("/update/available/tags").contentType(
+                MediaType.APPLICATION_JSON).content(json)).andExpect(
+                status().isOk())
+                .andDo(print()).andExpect(status().isOk())
+                .andExpect(jsonPath("$.error").value("Duplicate tag"));
     }
 
     @Test
@@ -57,9 +67,9 @@ public class ShadowControllerTest {
 
     @Test
     public void shadowControllerShouldReturnAvailableTags() throws Exception {
-        mockDataSource.getReportedTagsForDeviceToken("qatvZF2q7p0kV7CdZYOk") ;
+        mockDataSource.getAvailableTagsForDevice("abc") ;
         this.mockMvc.perform(get("/available/tags").contentType(
-                MediaType.APPLICATION_JSON).param("token","qatvZF2q7p0kV7CdZYOk")).andExpect(
+                MediaType.APPLICATION_JSON).param("deviceName","abc")).andExpect(
                 status().isOk())
                 .andDo(print()).andExpect(status().isOk());
     }
@@ -68,14 +78,14 @@ public class ShadowControllerTest {
     public void shadowControllerShouldReturnEmptyTagList() throws Exception {
         List<String> list = new ArrayList<>();
         this.mockMvc.perform(get("/available/tags").contentType(
-                MediaType.APPLICATION_JSON).param("token","Invalid")).andExpect(
+                MediaType.APPLICATION_JSON).param("deviceName","Invalid")).andExpect(
                 status().isOk())
-                .andDo(print()).andExpect(status().isOk()).andExpect(jsonPath("$.tags").value(list));
+                .andDo(print()).andExpect(status().isOk()).andExpect(jsonPath("$.tags").isEmpty());
     }
 
     @Test
     public void shadowControllerShouldReturnDesiredTagStatus() throws Exception {
-        String json = "{\"token\":\"abc\",\"tags\":[\"temp\",\"pressure\"]}";
+        String json = "{\"deviceName\":\"abc\",\"tags\":[\"temp\"]}";
         this.mockMvc.perform(post("/desired/tags").contentType(
                 MediaType.APPLICATION_JSON).content(json)).andExpect(
                 status().isOk())
@@ -85,7 +95,7 @@ public class ShadowControllerTest {
 
     @Test
     public void shadowControllerShouldReturnErrorInDesiredTagStatus() throws Exception {
-        String json = "{\"token\":\"abc\",\"tags\":[\"temp\",\"pressure\"]}";
+        String json = "{\"deviceName\":\"abc\",\"tags\":[\"temp\",\"pressure\"]}";
         this.mockMvc.perform(post("/desired/tags").contentType(
                 MediaType.APPLICATION_JSON).content(json)).andExpect(
                 status().isOk())
@@ -94,13 +104,25 @@ public class ShadowControllerTest {
     }
 
     @Test
-    public void shadowControllerShouldReturnError() throws Exception {
-        String json = "{\"token\":\"abc\",\"tags\":}";
-        String response = "com.fasterxml.jackson.core.JsonParseException: Unexpected character ('}' (code 125)): expected a valid value (number, String, array, object, 'true', 'false' or 'null')" +
-                " at [Source: {\"token\":\"abc\",\"tags\":}; line: 1, column: 24]";
-        this.mockMvc.perform(post("/desired/tags").contentType(MediaType.APPLICATION_JSON).content(json)).andExpect(
-                status().isOk());//.andExpect(jsonPath("$.error").exists());
+    public void shadowControllerShouldReturnReporedTagStatus() throws Exception {
+        String json = "{\"abc\":[\"temp\"]}";
+        this.mockMvc.perform(post("/reported/tags").contentType(
+                MediaType.APPLICATION_JSON).content(json)).andExpect(
+                status().isOk())
+                .andDo(print()).andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("updated"));
     }
+
+    @Test
+    public void shadowControllerShouldReturnErrorInReportedTagStatus() throws Exception {
+        String json = "{\"deviceName\":\"abc\",\"tags\":[\"temp]}";
+        this.mockMvc.perform(post("/reported/tags").contentType(
+                MediaType.APPLICATION_JSON).content(json)).andExpect(
+                status().isOk())
+                .andDo(print()).andExpect(status().isOk())
+                .andExpect(jsonPath("$.error").exists());
+    }
+
 }
 
 

--- a/Device-Management/src/test/java/org/thingsboard/device/shadow/ShadowControllerTest.java
+++ b/Device-Management/src/test/java/org/thingsboard/device/shadow/ShadowControllerTest.java
@@ -33,7 +33,7 @@ public class ShadowControllerTest {
     DeviceShadowDao mockDataSource;
 
     @Test
-    public void shadowControllerShouldReturnsUpdateStatus() throws Exception {
+    public void shadowControllerShouldReturnUpdateStatus() throws Exception {
         String json = "{\"token\":\"abc\",\"tags\":\"temp,pressure\"}";
         //String response = "{\"status\":\"updated\"}";
         this.mockMvc.perform(post("/update/available/tags").contentType(
@@ -44,7 +44,7 @@ public class ShadowControllerTest {
     }
 
     @Test
-    public void shadowControllerShouldReturnsErrorStatus() throws Exception {
+    public void shadowControllerShouldReturnErrorStatus() throws Exception {
         String json = "{\"sdc\":SDCSD}";
         //String response = "{\"status\":\"updated\"}";
         String response = "Unexpected character (S) at position 7.";
@@ -56,7 +56,7 @@ public class ShadowControllerTest {
     }
 
     @Test
-    public void shadowControllerShouldReturnsAvailableTags() throws Exception {
+    public void shadowControllerShouldReturnAvailableTags() throws Exception {
         mockDataSource.getReportedTagsForDeviceToken("qatvZF2q7p0kV7CdZYOk") ;
         this.mockMvc.perform(get("/available/tags").contentType(
                 MediaType.APPLICATION_JSON).param("token","qatvZF2q7p0kV7CdZYOk")).andExpect(
@@ -81,6 +81,16 @@ public class ShadowControllerTest {
                 status().isOk())
                 .andDo(print()).andExpect(status().isOk())
                 .andExpect(jsonPath("$.status").value("updated"));
+    }
+
+    @Test
+    public void shadowControllerShouldReturnErrorInDesiredTagStatus() throws Exception {
+        String json = "{\"token\":\"abc\",\"tags\":[\"temp\",\"pressure\"]}";
+        this.mockMvc.perform(post("/desired/tags").contentType(
+                MediaType.APPLICATION_JSON).content(json)).andExpect(
+                status().isOk())
+                .andDo(print()).andExpect(status().isOk())
+                .andExpect(jsonPath("$.error").exists());
     }
 
     @Test

--- a/extensions/extension-rest-api-call/src/main/java/org/thingsboard/server/extensions/rest/action/DeviceAttributeRestAction.java
+++ b/extensions/extension-rest-api-call/src/main/java/org/thingsboard/server/extensions/rest/action/DeviceAttributeRestAction.java
@@ -1,0 +1,92 @@
+package org.thingsboard.server.extensions.rest.action;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.thingsboard.server.common.data.kv.AttributeKvEntry;
+import org.thingsboard.server.common.msg.core.BasicUpdateAttributesRequest;
+import org.thingsboard.server.common.msg.device.ToDeviceActorMsg;
+import org.thingsboard.server.common.msg.session.ToDeviceMsg;
+import org.thingsboard.server.extensions.api.component.Action;
+import org.thingsboard.server.extensions.api.plugins.PluginAction;
+import org.thingsboard.server.extensions.api.plugins.msg.PluginToRuleMsg;
+import org.thingsboard.server.extensions.api.plugins.msg.RuleToPluginMsg;
+import org.thingsboard.server.extensions.api.rules.RuleContext;
+import org.thingsboard.server.extensions.api.rules.RuleProcessingMetaData;
+
+import java.util.*;
+
+@Action(name = "Device Attributes Rest Plugin Action",
+        descriptor = "DeviceAttributeRestDescriptor.json", configuration = RestApiCallPluginActionConfiguration.class)
+@Slf4j
+public class DeviceAttributeRestAction implements PluginAction<RestApiCallPluginActionConfiguration>{
+    private RestApiCallPluginActionConfiguration configuration;
+    @Override
+    public void resume() {
+
+    }
+
+    @Override
+    public void suspend() {
+
+    }
+
+    @Override
+    public void stop() {
+
+    }
+
+    @Override
+    public void init(RestApiCallPluginActionConfiguration configuration) {
+        this.configuration = configuration;
+    }
+
+    @Override
+    public Optional<RuleToPluginMsg<?>> convert(RuleContext ctx, ToDeviceActorMsg msg, RuleProcessingMetaData deviceMsgMd) {
+        BasicUpdateAttributesRequest payload;
+
+
+        if (msg.getPayload() instanceof BasicUpdateAttributesRequest) {
+            payload = (BasicUpdateAttributesRequest) msg.getPayload();
+        } else {
+            throw new IllegalArgumentException("Action does not support messages of type: " + msg.getPayload().getMsgType());
+        }
+
+        HashMap<String, String> attributes = new HashMap<>(payload.getAttributes().size());
+        for(AttributeKvEntry attr: payload.getAttributes()){
+            attributes.put(attr.getKey(), attr.getValueAsString());
+        }
+        ObjectMapper mapper = new ObjectMapper();
+        String msgBody;
+        try {
+            msgBody = mapper.writeValueAsString(attributes);
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException("Action does not support messages of type: " + msg.getPayload().getMsgType());
+        }
+        RestApiCallActionPayload.RestApiCallActionPayloadBuilder builder = RestApiCallActionPayload.builder();
+        builder.msgType(payload.getMsgType());
+        builder.requestId(payload.getRequestId());
+        builder.sync(configuration.isSync());
+        builder.actionPath(configuration.getActionPath());
+        builder.httpMethod(HttpMethod.valueOf(configuration.getRequestMethod()));
+        builder.expectedResultCode(HttpStatus.valueOf(configuration.getExpectedResultCode()));
+        builder.msgBody(msgBody);
+        return Optional.of(new RestApiCallActionMsg(msg.getTenantId(),
+                msg.getCustomerId(),
+                msg.getDeviceId(),
+                builder.build()));
+    }
+
+    @Override
+    public Optional<ToDeviceMsg> convert(PluginToRuleMsg<?> response) {
+        return null;
+    }
+
+    @Override
+    public boolean isOneWayAction() {
+        return false;
+    }
+
+}

--- a/extensions/extension-rest-api-call/src/main/java/org/thingsboard/server/extensions/rest/plugin/RestApiCallPlugin.java
+++ b/extensions/extension-rest-api-call/src/main/java/org/thingsboard/server/extensions/rest/plugin/RestApiCallPlugin.java
@@ -21,11 +21,12 @@ import org.thingsboard.server.extensions.api.component.Plugin;
 import org.thingsboard.server.extensions.api.plugins.AbstractPlugin;
 import org.thingsboard.server.extensions.api.plugins.PluginContext;
 import org.thingsboard.server.extensions.api.plugins.handlers.RuleMsgHandler;
+import org.thingsboard.server.extensions.rest.action.DeviceAttributeRestAction;
 import org.thingsboard.server.extensions.rest.action.RestApiCallPluginAction;
 
 import java.util.Base64;
 
-@Plugin(name = "REST API Call Plugin", actions = {RestApiCallPluginAction.class},
+@Plugin(name = "REST API Call Plugin", actions = {RestApiCallPluginAction.class, DeviceAttributeRestAction.class},
         descriptor = "RestApiCallPluginDescriptor.json", configuration = RestApiCallPluginConfiguration.class)
 @Slf4j
 public class RestApiCallPlugin extends AbstractPlugin<RestApiCallPluginConfiguration> {

--- a/extensions/extension-rest-api-call/src/main/resources/DeviceAttributeRestDescriptor.json
+++ b/extensions/extension-rest-api-call/src/main/resources/DeviceAttributeRestDescriptor.json
@@ -1,0 +1,51 @@
+{
+  "schema": {
+    "title": "REST API Call Action Configuration",
+    "type": "object",
+    "properties": {
+      "sync": {
+        "title": "Requires delivery confirmation",
+        "type": "boolean"
+      },
+      "actionPath": {
+        "title": "Action Path",
+        "type": "string",
+        "default": "/"
+      },
+      "requestMethod": {
+        "title": "Request method",
+        "type": "string"
+      },
+      "expectedResultCode": {
+        "title": "Expected Result Code",
+        "type": "integer"
+      }
+    },
+    "required": [
+      "sync",
+      "actionPath",
+      "expectedResultCode",
+      "requestMethod"
+    ]
+  },
+  "form": [
+    "sync",
+    "actionPath",
+    {
+      "key": "requestMethod",
+      "type": "rc-select",
+      "multiple": false,
+      "items": [
+        {
+          "value": "POST",
+          "label": "POST"
+        },
+        {
+          "value": "PUT",
+          "label": "PUT"
+        }
+      ]
+    },
+    "expectedResultCode"
+  ]
+}


### PR DESCRIPTION
Device management service for opcua data. It consist of a  device shadow store.
APIs:
1. /update/available/tags : POST
2. /available/tags : GET
3. /desired/tags : POST
4. / reported/tags: POST

Api 1 called through Thingsboard extension-rest-api-call and is used to update the list of available tags from OPC-UA server to device shadow store.

Api 2 is used to list all the available tags in device shadow store.

Api 3 is used to post the desired tags out of those available tags in device shadow store to getOPCData and mark them as desired.

Api 4 is used by getOPCData to update the state of those desired tags as reported in device shadow if the telemetry data for those tags is sent to thingsboard. 

